### PR TITLE
Add support for searching inside multiple spaces

### DIFF
--- a/app/repository/block_repo.go
+++ b/app/repository/block_repo.go
@@ -3,22 +3,44 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
 	"github.com/kudrykv/alfred-craftdocs-searchindex/app/types"
 )
 
-type BlockRepo struct {
-	db *sql.DB
+const (
+	searchResultLimit = 40
+)
+
+type Space struct {
+	ID string
+	DB *sql.DB
 }
 
-func NewBlockRepo(db *sql.DB) *BlockRepo {
-	return &BlockRepo{db: db}
+type BlockRepo struct {
+	spaces []Space
+}
+
+func NewBlockRepo(spaces ...Space) *BlockRepo {
+	return &BlockRepo{spaces: spaces}
+}
+
+func (br *BlockRepo) Close() (err error) {
+	for _, space := range br.spaces {
+		err2 := space.DB.Close()
+		if err == nil {
+			err = err2
+		}
+	}
+	return err
 }
 
 type Block struct {
 	ID           string
+	SpaceID      string
 	Content      string
 	DocumentID   string
 	DocumentName string
@@ -33,31 +55,45 @@ func (b *BlockRepo) Search(ctx context.Context, terms []string) ([]Block, error)
 		termsIface = append(termsIface, "%"+strings.ToLower(term)+"%")
 	}
 
-	query := "select id, content, documentId from BlockSearch where " + strings.Join(parts, " and ") + " limit 40"
-	rows, err := b.db.QueryContext(ctx, query, termsIface...)
-	if err != nil {
-		return nil, types.NewError("failed to query database", err)
-	}
-
-	defer func() { _ = rows.Close() }()
-
 	blocks := make([]Block, 0, 40)
+	for _, space := range b.spaces {
+		limit := searchResultLimit - len(blocks)
+		if limit == 0 {
+			break
+		}
+		log.Printf("Searching %s, limit %d", space.ID, limit)
 
-	for rows.Next() {
-		var block Block
-
-		if err = rows.Scan(&block.ID, &block.Content, &block.DocumentID); err != nil {
-			return nil, types.NewError("failed to scan a row", err)
+		query := fmt.Sprintf("select id, content, documentId from BlockSearch where %s limit %d", strings.Join(parts, " and "), limit)
+		rows, err := space.DB.QueryContext(ctx, query, termsIface...)
+		if err != nil {
+			return nil, types.NewError("failed to query database", err)
 		}
 
-		blocks = append(blocks, block)
-	}
+		for rows.Next() {
+			block := Block{SpaceID: space.ID}
 
-	if err = rows.Err(); err != nil {
-		return nil, types.NewError("error in rows", err)
+			if err = rows.Scan(&block.ID, &block.Content, &block.DocumentID); err != nil {
+				return nil, types.NewError("failed to scan a row", err)
+			}
+
+			blocks = append(blocks, block)
+		}
+
+		if err = rows.Err(); err != nil {
+			return nil, types.NewError("error in rows", err)
+		}
+
+		if err = rows.Close(); err != nil {
+			return nil, types.NewError("closing rows failed", err)
+		}
 	}
 
 	return blocks, nil
+}
+
+type docKey struct {
+	spaceID string
+	docID   string
 }
 
 func (b *BlockRepo) BackfillDocumentNames(ctx context.Context, blocks []Block) ([]Block, error) {
@@ -65,47 +101,58 @@ func (b *BlockRepo) BackfillDocumentNames(ctx context.Context, blocks []Block) (
 		return blocks, nil
 	}
 
-	docIDs := make(map[string]string, 40)
-
+	blocksBySpace := make(map[string][]Block)
 	for _, block := range blocks {
-		docIDs[block.DocumentID] = ""
+		blocksBySpace[block.SpaceID] = append(blocksBySpace[block.SpaceID], block)
 	}
 
-	ids := make([]interface{}, 0, len(docIDs))
-	for k := range docIDs {
-		ids = append(ids, k)
-	}
+	docIDs := make(map[docKey]string)
 
-	placeholders := make([]string, 0, len(ids))
-	for i := range ids {
-		placeholders = append(placeholders, "?"+strconv.Itoa(i+1))
-	}
+	for _, space := range b.spaces {
+		b := blocksBySpace[space.ID]
 
-	query := `select documentId, content from BlockSearch where entityType = 'document' and documentId in (` + strings.Join(placeholders, ", ") + ")"
-	rows, err := b.db.QueryContext(ctx, query, ids...)
-	if err != nil {
-		return nil, types.NewError("failed to query the database", err)
-	}
-
-	defer func() { _ = rows.Close() }()
-
-	for rows.Next() {
-		var block Block
-
-		if err = rows.Scan(&block.DocumentID, &block.Content); err != nil {
-			return nil, types.NewError("failed to scan row", err)
+		ids := make([]interface{}, 0, len(b))
+		for _, k := range b {
+			ids = append(ids, k.DocumentID)
 		}
 
-		docIDs[block.DocumentID] = block.Content
+		placeholders := make([]string, 0, len(ids))
+		for i := range ids {
+			placeholders = append(placeholders, "?"+strconv.Itoa(i+1))
+		}
+
+		query := `select documentId, content from BlockSearch where entityType = 'document' and documentId in (` + strings.Join(placeholders, ", ") + ")"
+		rows, err := space.DB.QueryContext(ctx, query, ids...)
+		if err != nil {
+			return nil, types.NewError("failed to query the database", err)
+		}
+
+		for rows.Next() {
+			var block Block
+
+			if err = rows.Scan(&block.DocumentID, &block.Content); err != nil {
+				return nil, types.NewError("failed to scan row", err)
+			}
+
+			docIDs[docKey{spaceID: space.ID, docID: block.DocumentID}] = block.Content
+		}
+
+		if err = rows.Err(); err != nil {
+			return nil, types.NewError("error in rows", err)
+		}
+
+		if err = rows.Close(); err != nil {
+			return nil, types.NewError("closing rows failed", err)
+		}
 	}
 
-	if err = rows.Err(); err != nil {
-		return nil, types.NewError("error in rows", err)
+	// Avoid mutating data in original slice.
+	backfilled := make([]Block, len(blocks))
+	copy(backfilled, blocks)
+
+	for i, block := range backfilled {
+		backfilled[i].DocumentName = docIDs[docKey{spaceID: block.SpaceID, docID: block.DocumentID}]
 	}
 
-	for i, block := range blocks {
-		blocks[i].DocumentName = docIDs[block.DocumentID]
-	}
-
-	return blocks, nil
+	return backfilled, nil
 }

--- a/app/service/block_service.go
+++ b/app/service/block_service.go
@@ -13,6 +13,10 @@ type BlockService struct {
 	br *repository.BlockRepo
 }
 
+func (bs *BlockService) Close() error {
+	return bs.br.Close()
+}
+
 func NewBlockService(br *repository.BlockRepo) *BlockService {
 	return &BlockService{br: br}
 }


### PR DESCRIPTION
This PR adds support for searching in multiple spaces.

One limitation is that the original 40 result limit is kept and no smarts are applied to try to pick the most relevant result(s). For this reason the secondary space results are simply appended after primary space results and may not show up at all if the primary space has >40 results.

Since search index for spaces are named as follows:

- Primary: `SearchIndex_aaa111ff-faaa-3a3a-1a2a-8000eddd2eee.sqlite`
- Secondary: `SearchIndex_aaa111ff-faaa-3a3a-1a2a-8000eddd2eee||f0000d50-30ab-baba-9191-0000bbbbdf50.sqlite`

I've relied on the `os.ReadDir` sort to guarantee that the "primary" space results are first.

Edit: I also opted not to parallelize the search of multiple spaces for V1 of this PR, a followup PR could improve upon the performance.