### PR TITLE
List documents first, differentiate between documents and blocks

### DIFF
--- a/app/initialize.go
+++ b/app/initialize.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	aw "github.com/deanishe/awgo"
 	"github.com/kudrykv/alfred-craftdocs-searchindex/app/config"
@@ -73,6 +74,18 @@ func workflow(ctx context.Context, wf *aw.Workflow, args []string) func() {
 
 			return
 		}
+
+		// Sort all documents (across spaces) on top, whilst maintaining
+		// order, primary space documents will always be on top.
+		sort.SliceStable(blocks, func(i, j int) bool {
+			if blocks[i].IsDocument() && !blocks[j].IsDocument() {
+				return true
+			}
+			if !blocks[i].IsDocument() && blocks[j].IsDocument() {
+				return false
+			}
+			return i < j
+		})
 
 		for _, block := range blocks {
 			wf.


### PR DESCRIPTION
Hey,

I thought it would be good to differentiate between blocks and documents (for my own sanity), and at the same time bringing the search results closer to what is produced by Craft.

This PR is part 1 (of 2, see #5 for part 2). In this PR we sort Documents on top and Blocks below (without otherwise affecting order). We also add `[Document]` or `[Block]` in the subtext. Here's a sample:

<img width="562" alt="image" src="https://user-images.githubusercontent.com/147409/150685470-e4e5ad5a-0cc8-49b2-a601-11b07d797f79.png">