### PR TITLE
Use FTS5 for search

### DIFF
--- a/app/initialize.go
+++ b/app/initialize.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	aw "github.com/deanishe/awgo"
 	"github.com/kudrykv/alfred-craftdocs-searchindex/app/config"
@@ -73,6 +74,18 @@ func workflow(ctx context.Context, wf *aw.Workflow, args []string) func() {
 
 			return
 		}
+
+		// Sort all documents (across spaces) on top, whilst maintaining
+		// order, primary space documents will always be on top.
+		sort.SliceStable(blocks, func(i, j int) bool {
+			if blocks[i].IsDocument() && !blocks[j].IsDocument() {
+				return true
+			}
+			if !blocks[i].IsDocument() && blocks[j].IsDocument() {
+				return false
+			}
+			return i < j
+		})
 
 		for _, block := range blocks {
 			wf.

--- a/app/main.go
+++ b/app/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"os"
-	"strings"
 
 	aw "github.com/deanishe/awgo"
 	"github.com/mattn/go-sqlite3"
@@ -19,16 +17,7 @@ func main() {
 
 //nolint:gochecknoinits
 func init() {
-	sql.Register("sqlite3_custom", &sqlite3.SQLiteDriver{
-		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-			err := conn.RegisterFunc("utf8lower", strings.ToLower, true)
-			if err != nil {
-				return fmt.Errorf("register utf8lower func: %w", err)
-			}
-
-			return nil
-		},
-	})
+	sql.Register("sqlite3_custom", &sqlite3.SQLiteDriver{})
 
 	if len(os.Getenv("alfred_workflow_bundleid")) == 0 {
 		if err := os.Setenv("alfred_workflow_bundleid", "dev.kudrykv.craftsearchindex"); err != nil {

--- a/app/service/block_service.go
+++ b/app/service/block_service.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/kudrykv/alfred-craftdocs-searchindex/app/repository"
 )
@@ -21,11 +19,7 @@ func NewBlockService(br *repository.BlockRepo) *BlockService {
 	return &BlockService{br: br}
 }
 
-var regexCleanSpaces = regexp.MustCompile(`\s+`)
-
 func (r *BlockService) Search(ctx context.Context, args []string) ([]repository.Block, error) {
-	args = strings.Split(regexCleanSpaces.ReplaceAllString(strings.Join(args, " "), " "), " ")
-
 	blocks, err := r.br.Search(ctx, args)
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)


### PR DESCRIPTION
This PR is part 2 (of 2), a continuation of #4. (Please note that the commit from #4 is included here.)

There are a couple of things going on here:
- Search results are affected due to the use of `MATCH` vs `LIKE`
  - Matching only supports full words or prefixes, we can match `Hello` with `hel*`, but we can't match it with `*ello`.
  - This behaves the same as the Craft built-in search
- Search results are ordered similarly to those produced by the Craft built-in search
  - This is due to sorting on `rank` (produced by `MATCH`) and including `customRank` which is likely used in the built-in search
  - It's not a 100% match to Craft results as there is probably still some internal sort criteria that further boosts/deprioritizes some results
  - I managed to get the results even closer by using subqueries and sorting them separately, but whilst it in many cases produced exact results, it skewed some others (simplicity won here)
- Performance in the worst case is improved (due to `MATCH` vs `LIKE`)
  - Example: Across 4 spaces with non-performant keywords, search speed went from 150ms to 15ms
- Non-ASCII characters are now supported (better?)
  - I had problems characters containing diacritics (e.g. `åäö`) when using `LIKE` and going via Go.
  - This seemed to be due to UTF-8 encoding which resulted in zero matches. Writing the same query in `sqlite3` cli worked, on the other hand.
  - The FTS5 MATCH drops all diacritics so `ö` and `o` are the same.
- Empty search produces more relevant matches (by sorting on customRank)

Here's a before and after:

<img width="562" alt="image" src="https://user-images.githubusercontent.com/147409/150685470-e4e5ad5a-0cc8-49b2-a601-11b07d797f79.png">

<img width="560" alt="image" src="https://user-images.githubusercontent.com/147409/150685548-66f2d8a7-ebbf-4c77-a4d1-bd8d5a9a7a4c.png">
