### PR TITLE
Fix bug in fts5 search when query includes "

### DIFF
--- a/app/repository/block_repo.go
+++ b/app/repository/block_repo.go
@@ -72,6 +72,7 @@ func buildMatchQuery(terms []string) string {
 	for _, term := range terms {
 		// Quote the term to avoid FTS5 bareword input sanitization.
 		// https://www.sqlite.org/fts5.html#fts5_strings
+		term = strings.ReplaceAll(term, "\"", " ")
 		quotedTerms = append(quotedTerms, fmt.Sprintf("%q", term))
 	}
 	// Create different permutations of the match phrase (with and


### PR DESCRIPTION
This PR fixes a bug in the FTS5 search when the query includes the double quote (`"`)-character.

Since FTS search does not support searching for `"`, it is simple replaced by a space which should work in all cases.

The error (before):
<img width="570" alt="image" src="https://user-images.githubusercontent.com/147409/164289940-c04a3d04-502b-4216-af64-eccbfa5c65cc.png">